### PR TITLE
Add .gitignore and optional images dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+.env/
+.venv/
+venv/
+ENV/
+
+# Large or optional datasets
+images/
+data/
+datasets/
+
+# Other
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ Observations:
    pip install -r requirements.txt
    ```
 3. Install [Tesseract OCR](https://github.com/tesseract-ocr/tesseract). After installation you can modify `pytesseract.pytesseract.tesseract_cmd` in `Preprocessing.py` if necessary.
+4. The `images/` directory with sample captchas is optional. You can download it
+   later by running `scripts/download_images.sh` or from the project's release
+   page.
 
 ## Usage
 Run the main program and follow the prompts:

--- a/README_en.md
+++ b/README_en.md
@@ -110,6 +110,9 @@ Observations:
    pip install -r requirements.txt
    ```
 3. Install [Tesseract OCR](https://github.com/tesseract-ocr/tesseract). After installation you can modify `pytesseract.pytesseract.tesseract_cmd` in `Preprocessing.py` if necessary.
+4. The `images/` directory with sample captchas is optional. You can download it
+   later by running `scripts/download_images.sh` or from the project's release
+   page.
 
 ## Usage
 Run the main program and follow the prompts:

--- a/scripts/download_images.sh
+++ b/scripts/download_images.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Download sample images dataset for PyCaptcha-Toolkit
+set -e
+
+TARGET_DIR="$(dirname "$0")/../images"
+mkdir -p "$TARGET_DIR"
+
+URL=${1:-"https://github.com/lukeyu1025/CaptchaReader/releases/latest/download/images.zip"}
+
+echo "Downloading images from $URL"
+
+curl -L "$URL" -o /tmp/images.zip
+unzip -o /tmp/images.zip -d "$TARGET_DIR"
+rm /tmp/images.zip
+
+echo "Images downloaded to $TARGET_DIR"


### PR DESCRIPTION
## Summary
- ignore Python build artifacts, virtualenvs, and datasets
- document that `images/` is optional and can be downloaded
- provide `scripts/download_images.sh` helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854710a49fc832b89fc5676097a68f9