### PR TITLE
Add preprocessing and show_rate tests

### DIFF
--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,39 @@
+import pytest
+
+np = pytest.importorskip('numpy')
+cv2 = pytest.importorskip('cv2')
+
+from Preprocessing import bw, morph_image, blur_image
+
+
+def test_bw_threshold_path():
+    # image with black corners -> threshold should use global thresholding
+    img = np.full((3, 3), 255, dtype=np.uint8)
+    img[0, 0] = img[0, 2] = img[2, 0] = img[2, 2] = 0
+    result = bw(img)
+    # corners remain black, others white
+    expected = img.copy()
+    expected[1, 0] = expected[0, 1] = expected[1, 2] = expected[2, 1] = 255
+    expected[1, 1] = 255
+    assert np.array_equal(result, expected)
+
+
+def test_bw_adaptive_path():
+    # image entirely white -> adaptive threshold keeps it white
+    img = np.full((3, 3), 255, dtype=np.uint8)
+    result = bw(img)
+    assert np.array_equal(result, img)
+
+
+def test_morph_image_closing_fills_hole():
+    img = np.full((5, 5), 255, dtype=np.uint8)
+    img[2, 2] = 0
+    result = morph_image(img)
+    assert result[2, 2] == 255
+
+
+def test_blur_image_median():
+    img = np.full((3, 3), 255, dtype=np.uint8)
+    img[1, 1] = 0
+    result = blur_image(img)
+    assert result[1, 1] == 255

--- a/tests/test_process_manage.py
+++ b/tests/test_process_manage.py
@@ -1,0 +1,37 @@
+import os
+import builtins
+import pytest
+
+np = pytest.importorskip('numpy')
+
+import process_manage
+
+
+def test_show_rate(monkeypatch, tmp_path, capsys):
+    # create dummy png files
+    (tmp_path / "111111.png").write_text("data")
+    (tmp_path / "222222.png").write_text("data")
+
+    # fake get_image returning the label as image as well
+    def fake_get_image(path):
+        label = os.path.splitext(os.path.basename(path))[0]
+        return label, label
+
+    monkeypatch.setattr('load.get_image', fake_get_image)
+
+    # choose_process returns simple order
+    monkeypatch.setattr(process_manage, 'choose_process', lambda: [])
+
+    # replace process to just echo label as text
+    def fake_process(original_image, order):
+        return process_manage.Result(order, [original_image]*5, original_image)
+
+    monkeypatch.setattr(process_manage, 'process', fake_process)
+
+    inputs = iter([str(tmp_path), ''])
+    monkeypatch.setattr(builtins, 'input', lambda: next(inputs))
+
+    process_manage.show_rate()
+    out = capsys.readouterr().out
+    assert 'Out of 12 letters 12 were correctly read.' in out
+    assert 'Out of 2 captcha images, 2 were correctly read.' in out


### PR DESCRIPTION
## Summary
- create tests for `bw`, `morph_image`, and `blur_image`
- test `show_rate` using mocked process and get_image functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685471087e0c832b827f0eac7e6f2e12