### PR TITLE
Add argparse CLI for CaptchaBreaker

### DIFF
--- a/CaptchaBreaker.py
+++ b/CaptchaBreaker.py
@@ -1,6 +1,16 @@
+import argparse
 import process_manage
 import cv2
 from load import get_image
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Run captcha preprocessing or evaluate a dataset.')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-i', '--image', help='Path to a single image to process')
+    group.add_argument('-d', '--dataset', help='Path to a folder of captcha images')
+    return parser.parse_args()
 
 def menu():
     print('Choose operation')
@@ -19,22 +29,40 @@ def menu():
 
 
 if __name__ == '__main__':
-    while True:
-        choice = menu()
-        if choice == 1:
-            print('Enter full path for image')
-            get_input = str(input()) #input of path
-            try:
-                image, label = get_image(get_input)  # use path to get image
-                sel_order = process_manage.choose_process()
-                res = process_manage.process(image, sel_order)
-                res.show()
-                print(label)
-            except FileNotFoundError as e:
-                print(e)
-            except cv2.error:
-                print('Error reading the image. Please provide a valid image file.\n')
-        elif choice == 2:
-            process_manage.show_rate()
-        elif choice == 3:
-            raise SystemExit
+    args = parse_args()
+    if args.image:
+        try:
+            image, label = get_image(args.image)
+            sel_order = process_manage.choose_process()
+            res = process_manage.process(image, sel_order)
+            res.show()
+            print(label)
+        except FileNotFoundError as e:
+            print(e)
+        except cv2.error:
+            print('Error reading the image. Please provide a valid image file.\n')
+    elif args.dataset:
+        try:
+            process_manage.show_rate(args.dataset)
+        except FileNotFoundError as e:
+            print(e)
+    else:
+        while True:
+            choice = menu()
+            if choice == 1:
+                print('Enter full path for image')
+                get_input = str(input())  # input of path
+                try:
+                    image, label = get_image(get_input)
+                    sel_order = process_manage.choose_process()
+                    res = process_manage.process(image, sel_order)
+                    res.show()
+                    print(label)
+                except FileNotFoundError as e:
+                    print(e)
+                except cv2.error:
+                    print('Error reading the image. Please provide a valid image file.\n')
+            elif choice == 2:
+                process_manage.show_rate()
+            elif choice == 3:
+                raise SystemExit

--- a/README.md
+++ b/README.md
@@ -112,8 +112,17 @@ Observations:
 3. Install [Tesseract OCR](https://github.com/tesseract-ocr/tesseract). After installation you can modify `pytesseract.pytesseract.tesseract_cmd` in `Preprocessing.py` if necessary.
 
 ## Usage
-Run the main program and follow the prompts:
+You can now run the program non–interactively using command line flags or fall back
+to the original prompts.
 
+Process a single image:
 ```bash
-python CaptchaBreaker.py
+python CaptchaBreaker.py --image path/to/captcha.png
 ```
+
+Evaluate all images in a folder:
+```bash
+python CaptchaBreaker.py --dataset path/to/folder
+```
+
+If no arguments are provided the interactive menu is displayed as before.

--- a/README_en.md
+++ b/README_en.md
@@ -112,8 +112,16 @@ Observations:
 3. Install [Tesseract OCR](https://github.com/tesseract-ocr/tesseract). After installation you can modify `pytesseract.pytesseract.tesseract_cmd` in `Preprocessing.py` if necessary.
 
 ## Usage
-Run the main program and follow the prompts:
+Run the program from the command line or use the interactive mode.
 
+Process a single image:
 ```bash
-python CaptchaBreaker.py
+python CaptchaBreaker.py --image path/to/captcha.png
 ```
+
+Evaluate all images in a folder:
+```bash
+python CaptchaBreaker.py --dataset path/to/folder
+```
+
+If no arguments are given the original menu-based interface is shown.

--- a/process_manage.py
+++ b/process_manage.py
@@ -79,17 +79,23 @@ def choose_process():
 
 
 # Compute and display success rate for images in given path
-def show_rate():
+def show_rate(data_path=None):
     current_path = os.path.dirname(__file__)
     print('* Current path = ' + current_path)
-    print('Enter path of dataset')
-    while True:
+    if data_path is None:
+        print('Enter path of dataset')
+        while True:
+            try:
+                data_path = input()
+                total = len(fnmatch.filter(os.listdir(data_path), '*.png'))
+                break
+            except FileNotFoundError:
+                print('Wrong path. Try again.')
+    else:
         try:
-            data_path = input()
             total = len(fnmatch.filter(os.listdir(data_path), '*.png'))
-            break
         except FileNotFoundError:
-            print('Wrong path. Try again.')
+            raise FileNotFoundError('Dataset path not found.')
 
     order = choose_process()
 
@@ -118,6 +124,6 @@ def show_rate():
     print('\tOut of {0} captcha images, {1} were correctly read.'
           'Success Rate: {2:.2f}%'
           .format(total, correct, (correct * 100) / total))
-    print('Press any key to continue.')
-
-    input()
+    if data_path is None:
+        print('Press any key to continue.')
+        input()


### PR DESCRIPTION
## Summary
- add `argparse` options for image or dataset processing
- allow `show_rate` to accept a dataset path
- keep interactive fallback when arguments are omitted
- update README files with CLI examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685471071c78832b885da6b820d1f12c