### PR TITLE
Fix crop_image dtype conversion and add test

### DIFF
--- a/Preprocessing.py
+++ b/Preprocessing.py
@@ -33,7 +33,7 @@ def crop_image(original_image):
     if corners is None:
         return original_image
 
-    corners = np.int0(corners)
+    corners = corners.astype(int)
     for i in corners:
         x, y = i.ravel()
         if x > cut and y > cut:

--- a/tests/test_crop_image.py
+++ b/tests/test_crop_image.py
@@ -17,3 +17,11 @@ def test_crop_image_returns_original_when_not_enough_corners():
     img[5, 5] = 0  # single black pixel to create a single corner
     result = crop_image(img)
     assert np.array_equal(result, img)
+
+
+def test_crop_image_crops_with_multiple_corners():
+    img = np.full((20, 20), 255, dtype=np.uint8)
+    cv2.rectangle(img, (5, 5), (14, 14), 0, 1)
+    result = crop_image(img)
+    assert result.shape == (19, 19)
+    assert not np.array_equal(result, img)


### PR DESCRIPTION
## Summary
- use `corners.astype(int)` in `crop_image`
- test cropping works when multiple corners exist

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: numpy & cv2, tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68547105feb0832b8c6a469a2be63904